### PR TITLE
Added `GetSize` method to Buffer class

### DIFF
--- a/OpenDDL/Code/TSTools.h
+++ b/OpenDDL/Code/TSTools.h
@@ -205,6 +205,12 @@ namespace Terathon
 				return (reinterpret_cast<type *>(bufferStorage));
 			}
 
+			template <typename type>
+			uint32 GetSize(void) const
+			{
+				return bufferSize / sizeof(type);
+			}
+
 			void AllocateBuffer(uint32 size)
 			{
 				if (size != bufferSize)


### PR DESCRIPTION
It seems there's no way to get the size of the buffer in the above class, which I needed it to properly read Base64 binary data.